### PR TITLE
Add tag as command line option

### DIFF
--- a/lib/command/privatize_posts.rb
+++ b/lib/command/privatize_posts.rb
@@ -5,11 +5,14 @@ class Command::PrivatizePosts < Command
 
   sig {params(options: Options, config: Config, client: TumblrClient).void}
   def call(options, config, client)
-    # Get our initial response.
+    # make our base query params
     page_query_params = PageQueryParams.new(
       before: options.beginning_timestamp,
       tumblelog: config.tumblr_blog_url,
     )
+
+    # add tag if we have one
+    page_query_params.tag = options.tag unless options.tag.nil?
 
     stats = T.let(Stats.new, Stats)
 
@@ -21,8 +24,7 @@ class Command::PrivatizePosts < Command
         stats.loop_iterations += 1
         puts "New interation: #{stats.loop_iterations}" if options.verbose
 
-        # If there are no more posts, notify and break.
-        # The API seems to, uh, have different responses. 😅
+        # if there are no more posts, break!
         unless response.has_posts?
           puts "No more posts!" if options.verbose
           break

--- a/lib/lib/options.rb
+++ b/lib/lib/options.rb
@@ -11,6 +11,7 @@ class Options < T::Struct
   prop :beginning_timestamp, Integer, default: Options.get_timestamp(Date.today)
   prop :config_file, String, default: Config::DEFAULT_CONFIG_FILE_PATH
   prop :verbose, T::Boolean, default: false
+  prop :tag, T.nilable(String)
 
   sig {returns(Options)}
   def self.parse_options
@@ -24,12 +25,16 @@ class Options < T::Struct
     OptionParser.new do |opts|
       opts.banner = 'Usage: ruby script.rb [options]'
 
-      opts.on('-dSTART_DATE', '--start_date=START_DATE', "The date to start privatizing posts, in YYYY-DD-MM format (default: today)") do |d|
+      opts.on('-dSTART_DATE', '--start_date=START_DATE', 'The date to start privatizing posts, in YYYY-DD-MM format (default: today)') do |d|
         options.beginning_timestamp = Options.calculate_beginning_timestamp!(d)
         continue_prompt = false
       end
 
-      opts.on('-v', '--verbose', "Print debug-y information") { options.verbose = true }
+      opts.on('--tTAG', '--tag=TAG', 'The tag of the posts to turn private') do |t|
+        options.tag = t
+      end
+
+      opts.on('-v', '--verbose', 'Print debug-y information') { options.verbose = true }
 
       opts.on('-h', '--help', 'Prints this help') do
         puts opts

--- a/lib/lib/page_query_params.rb
+++ b/lib/lib/page_query_params.rb
@@ -8,4 +8,5 @@ class PageQueryParams < T::Struct
   prop :before, Integer
   prop :tumblelog, String
   prop :page_number, T.nilable(String)
+  prop :tag, T.nilable(String)
 end


### PR DESCRIPTION
The script can now be run with `--tag=<tag>` to privatize posts with a certain tag!

Examples:

(on macOS:)
```bash
ruby script.rb --start_date=$(date -v -1d '+%F') --tag="delete tomorrow" --verbose
```

(on *nix:)
```bash
ruby script.rb --start_date=$(TZ="America/New_York" date --date='-1 day' +%F) --tag="delete tomorrow" --verbose
```